### PR TITLE
remove usage of deprecated `default` arg for dials parameter objects

### DIFF
--- a/R/params.R
+++ b/R/params.R
@@ -18,7 +18,6 @@ h2o_activation <- function(values = values_h2o_activation) {
   dials::new_qual_param(
     type = "character",
     values = values,
-    default = "none",
     label = c(h2o_activation = "Activation function")
   )
 }
@@ -31,7 +30,6 @@ h2o_split <- function(values = values_h2o_split) {
   dials::new_qual_param(
     type = "character",
     values = values,
-    default = "none",
     label = c(h2o_split = "Type of histogram to find optimal splits")
   )
 }


### PR DESCRIPTION
The next version of dials will deprecate the `default` argument to the constructors `dials::new_quant_param()` and `dials::new_qual_param()` so this PR removes usage of those arguments.

Should `"none"` be added to `values_h2o_activation` and `values_h2o_split` so that it's still part of the default set?

For more context: https://github.com/tidymodels/dials/pull/241