### PR TITLE
add new arguments from tune

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: agua
 Title: 'tidymodels' Integration with 'h2o'
-Version: 0.1.3
+Version: 0.1.3.9000
 Authors@R: c(
     person("Max", "Kuhn", , "max@posit.co", role = "aut",
            comment = c(ORCID = "0000-0003-2402-136X")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,7 @@ Config/Needs/website:
   tidymodels,
   vip
 Remotes:
-  tidymodels/tune#793
+  tidymodels/tune
 Config/testthat/edition: 3
 Config/testthat/parallel: false
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     stats,
     tibble,
     tidyr,
-    tune (>= 1.0.1),
+    tune (>= 1.1.2.9007),
     vctrs,
     workflows
 Suggests:
@@ -50,6 +50,8 @@ Config/Needs/website:
   doParallel,
   tidymodels,
   vip
+Remotes:
+  tidymodels/tune
 Config/testthat/edition: 3
 Config/testthat/parallel: false
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,7 @@ Config/Needs/website:
   tidymodels,
   vip
 Remotes:
-  tidymodels/tune
+  tidymodels/tune#793
 Config/testthat/edition: 3
 Config/testthat/parallel: false
 Encoding: UTF-8

--- a/R/tune.R
+++ b/R/tune.R
@@ -11,7 +11,10 @@ tune_grid_loop_iter_agua <- function(split,
                                      workflow,
                                      metrics,
                                      control,
-                                     seed) {
+                                     eval_time = NULL,
+                                     seed,
+                                     metrics_info = NULL,
+                                     params = NULL) {
   h2o::h2o.no_progress(
     tune_grid_loop_iter_agua_impl(
       split,
@@ -309,7 +312,8 @@ pull_h2o_metrics <- function(predictions,
     metrics,
     param_names,
     outcome_name,
-    event_level
+    event_level,
+    metrics_info = tune::metrics_info(metrics)
   )
   metrics %>% dplyr::bind_cols(fold_id)
 }


### PR DESCRIPTION
PR 2/2, following up on tidymodels/tune#784. Will add some further context there. 


I _believe_ the censored regression mode isn't available in h2o anyway, so we'll never actually hit a point where a non-NULL `eval_time` makes it to this machinery. 

The remaining changes, for `metrics_info` and `params`, are optional performance optimizations from recent versions of tune. 

I believe all of the tune-related tests in this repo are skipped on CRAN. This would mean that tune goes in first, tuning with agua is broken for the meantime (as it already is), and then we submit agua once tune is ready to go.