### PR TITLE
bump tune version to CRAN

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     stats,
     tibble,
     tidyr,
-    tune (>= 1.1.2.9007),
+    tune (>= 1.2.0),
     vctrs,
     workflows
 Suggests:
@@ -50,8 +50,6 @@ Config/Needs/website:
   doParallel,
   tidymodels,
   vip
-Remotes:
-  tidymodels/tune
 Config/testthat/edition: 3
 Config/testthat/parallel: false
 Encoding: UTF-8


### PR DESCRIPTION
A follow-up to #52. Now that tune 1.2.0 made it to CRAN a couple weeks ago, the recent changes in agua should be ready to go to CRAN! This will resolve #53 and https://github.com/tidymodels/tune/issues/882. After merging this PR, you should be ready to start the release cycle with `usethis::use_release_issue()`. Please feel free to let me know if you'd appreciated any help making this CRAN release happen. :)